### PR TITLE
Publish initial joint state before service creation

### DIFF
--- a/src/gripper_service/src/gripper_service.cpp
+++ b/src/gripper_service/src/gripper_service.cpp
@@ -21,6 +21,16 @@ GripperService::GripperService()
   joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
     "/joint_states", 10);
 
+  // Publish an initial joint state so that other nodes know the
+  // gripper joint exists before any commands are sent.
+  {
+    sensor_msgs::msg::JointState js;
+    js.header.stamp = this->now();
+    js.name = {"joint_finger"};
+    js.position = {0.0};
+    joint_state_pub_->publish(js);
+  }
+
   service =
     this->create_service<cms_beamtime_interfaces::srv::GripperControlMsg>(
     "gripper_service",


### PR DESCRIPTION
## Summary
- make gripper service publish an initial `joint_finger` position

## Testing
- `bash test.sh` *(fails: `colcon: command not found`)*

------
