### PR TITLE
Publish initial joint state with persistent QoS

### DIFF
--- a/src/gripper_service/src/gripper_service.cpp
+++ b/src/gripper_service/src/gripper_service.cpp
@@ -18,8 +18,20 @@ GripperService::GripperService()
 
   RCLCPP_INFO(this->get_logger(), "Activation is successful");
 
+  rclcpp::QoS qos(rclcpp::KeepLast(1));
+  qos.transient_local();
   joint_state_pub_ = this->create_publisher<sensor_msgs::msg::JointState>(
-    "/joint_states", 10);
+    "/joint_states", qos);
+
+  // Publish an initial joint state so that other nodes know the
+  // gripper joint exists before any commands are sent.
+  {
+    sensor_msgs::msg::JointState js;
+    js.header.stamp = this->now();
+    js.name = {"joint_finger"};
+    js.position = {0.0};
+    joint_state_pub_->publish(js);
+  }
 
   service =
     this->create_service<cms_beamtime_interfaces::srv::GripperControlMsg>(


### PR DESCRIPTION
## Summary
- use `transient_local` QoS for the gripper `joint_state` publisher
- publish the startup joint state once to announce `joint_finger`

## Testing
- `bash test.sh` *(fails: Has this package been built before?)*

------
