### PR TITLE
Allow disabling joint constraint via parameter

### DIFF
--- a/src/cms_beamtime/README.md
+++ b/src/cms_beamtime/README.md
@@ -3,7 +3,13 @@
 Node pdf_beamtime_server is implemented in pdf_beamtime_server.cpp. This nodes,
  - Performs motion planning for the robot through a Finite State Machine (FSM)
  - Reads the parameter server and creates the obstacles,
- - Implements servers for creating new obstacles, deleting and updating existing ones. 
+ - Implements servers for creating new obstacles, deleting and updating existing ones.
+
+### Parameters
+
+`use_joint_constraints` *(bool)* – when set to `true` (default), the server applies
+a joint constraint to the wrist during motion planning. Set this parameter to
+`false` to disable the constraint entirely.
 
 Services can be called by following the examples below:
 

--- a/src/cms_beamtime/cms_beamtime/cms_beamtime_server.py
+++ b/src/cms_beamtime/cms_beamtime/cms_beamtime_server.py
@@ -60,6 +60,8 @@ class cmsBeamtimeServer(Node):
         safe_declare("joint_constraints.joint_position", ParameterType.PARAMETER_DOUBLE)
         safe_declare("joint_constraints.upper_limit", ParameterType.PARAMETER_DOUBLE)
         safe_declare("joint_constraints.lower_limit", ParameterType.PARAMETER_DOUBLE)
+        if not self.has_parameter("use_joint_constraints"):
+            self.declare_parameter("use_joint_constraints", True)
 
         self.tf_utils = TFUtilities(self)
         self.inner_sm = InnerStateMachine(self, self)
@@ -89,23 +91,26 @@ class cmsBeamtimeServer(Node):
             cancel_callback=self.handle_cancel,
             callback_group=ReentrantCallbackGroup(),
         )
-        ## Joint constraints for wrist mov
-        jc_name = self.get_parameter("joint_constraints.joint_name").value
-        jc_pos = self.get_parameter("joint_constraints.joint_position").value
-        jc_upper = self.get_parameter("joint_constraints.upper_limit").value
-        jc_lower = self.get_parameter("joint_constraints.lower_limit").value
+        ## Joint constraints for wrist mov (optional)
+        use_constraints = self.get_parameter("use_joint_constraints").value
+        if use_constraints:
+            jc_name = self.get_parameter("joint_constraints.joint_name").value
+            jc_pos = self.get_parameter("joint_constraints.joint_position").value
+            jc_upper = self.get_parameter("joint_constraints.upper_limit").value
+            jc_lower = self.get_parameter("joint_constraints.lower_limit").value
 
-        jc = JointConstraint()
-        jc.joint_name = jc_name
-        jc.position = jc_pos
-        jc.tolerance_above = jc_upper - jc.position
-        jc.tolerance_below = jc.position - jc_lower
-        jc.weight = 1.0
+            jc = JointConstraint()
+            jc.joint_name = jc_name
+            jc.position = jc_pos
+            jc.tolerance_above = jc_upper - jc.position
+            jc.tolerance_below = jc.position - jc_lower
+            jc.weight = 1.0
 
-        constraints = Constraints()
-        constraints.joint_constraints = [jc]
-
-        self.path_constraints = constraints
+            constraints = Constraints()
+            constraints.joint_constraints = [jc]
+            self.path_constraints = constraints
+        else:
+            self.path_constraints = None
         # Cleanup strategy: 'step' follows the path back, 'home' goes straight home
         if not self.has_parameter("cleanup_mode"):
             self.declare_parameter("cleanup_mode", "step")

--- a/src/cms_beamtime/config/joint_poses.yaml
+++ b/src/cms_beamtime/config/joint_poses.yaml
@@ -1,6 +1,7 @@
 cms_beamtime_server:
   ros__parameters:
     home_angles: [0.0, -1.5708, 0.00, -1.5708, 0.0, 3.14159] # Home angles for the robot
+    use_joint_constraints: true
     joint_constraints:
       joint_name: 'wrist_3_joint'
       joint_position: 3.14159


### PR DESCRIPTION
## Summary
- allow disabling path constraints in `cms_beamtime_server`
- add `use_joint_constraints` parameter to default config
- document the parameter in the README

## Testing
- `bash test.sh` *(fails: `colcon: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68407e25a6d0832eaedb06b5e32611a8