### PR TITLE
Add gripper service trajectory controller

### DIFF
--- a/src/gripper_service_trajectory_controller/CMakeLists.txt
+++ b/src/gripper_service_trajectory_controller/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.8)
+project(gripper_service_trajectory_controller)
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic)
+endif()
+
+find_package(ament_cmake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(rclcpp_action REQUIRED)
+find_package(rclcpp_components REQUIRED)
+find_package(controller_interface REQUIRED)
+find_package(hardware_interface REQUIRED)
+find_package(pluginlib REQUIRED)
+find_package(trajectory_msgs REQUIRED)
+find_package(cms_beamtime_interfaces REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+include_directories(include)
+
+add_library(${PROJECT_NAME} SHARED
+  src/gripper_service_trajectory_controller.cpp
+)
+
+ament_target_dependencies(${PROJECT_NAME}
+  rclcpp
+  rclcpp_action
+  rclcpp_components
+  controller_interface
+  hardware_interface
+  pluginlib
+  trajectory_msgs
+  cms_beamtime_interfaces
+  sensor_msgs
+)
+
+pluginlib_export_plugin_description_file(controller_interface gripper_service_trajectory_controller.xml)
+
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+install(DIRECTORY include/
+  DESTINATION include
+)
+
+ament_package()

--- a/src/gripper_service_trajectory_controller/gripper_service_trajectory_controller.xml
+++ b/src/gripper_service_trajectory_controller/gripper_service_trajectory_controller.xml
@@ -1,0 +1,5 @@
+<library path="gripper_service_trajectory_controller">
+  <class name="gripper_service_trajectory_controller/GripperServiceTrajectoryController" type="gripper_service_trajectory_controller::GripperServiceTrajectoryController" base_class_type="controller_interface::ControllerInterface">
+    <description>Translate joint trajectories into gripper service calls.</description>
+  </class>
+</library>

--- a/src/gripper_service_trajectory_controller/include/gripper_service_trajectory_controller/gripper_service_trajectory_controller.hpp
+++ b/src/gripper_service_trajectory_controller/include/gripper_service_trajectory_controller/gripper_service_trajectory_controller.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <controller_interface/controller_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <rclcpp_action/rclcpp_action.hpp>
+#include <trajectory_msgs/msg/joint_trajectory.hpp>
+#include <realtime_tools/realtime_buffer.h>
+#include <cms_beamtime_interfaces/srv/gripper_control_msg.hpp>
+#include <sensor_msgs/msg/joint_state.hpp>
+
+namespace gripper_service_trajectory_controller
+{
+class GripperServiceTrajectoryController : public controller_interface::ControllerInterface
+{
+public:
+  GripperServiceTrajectoryController();
+
+  controller_interface::InterfaceConfiguration command_interface_configuration() const override;
+
+  controller_interface::InterfaceConfiguration state_interface_configuration() const override;
+
+  controller_interface::return_type update(const rclcpp::Time & time, const rclcpp::Duration & period) override;
+
+  controller_interface::CallbackReturn on_init() override;
+
+  controller_interface::CallbackReturn on_activate(const rclcpp_lifecycle::State & previous_state) override;
+
+  controller_interface::CallbackReturn on_deactivate(const rclcpp_lifecycle::State & previous_state) override;
+
+private:
+  void traj_callback(const trajectory_msgs::msg::JointTrajectory::SharedPtr msg);
+  realtime_tools::RealtimeBuffer<trajectory_msgs::msg::JointTrajectory> traj_buffer_;
+  rclcpp::Subscription<trajectory_msgs::msg::JointTrajectory>::SharedPtr traj_sub_;
+  rclcpp::Client<cms_beamtime_interfaces::srv::GripperControlMsg>::SharedPtr gripper_client_;
+  rclcpp::Publisher<sensor_msgs::msg::JointState>::SharedPtr joint_state_pub_;
+};
+}  // namespace gripper_service_trajectory_controller

--- a/src/gripper_service_trajectory_controller/package.xml
+++ b/src/gripper_service_trajectory_controller/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="3">
+  <name>gripper_service_trajectory_controller</name>
+  <version>0.0.0</version>
+  <description>Controller that bridges FollowJointTrajectory commands to the gripper service.</description>
+  <maintainer email="unknown@todo.todo">TODO</maintainer>
+  <license>BSD-3-Clause</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_action</depend>
+  <depend>rclcpp_components</depend>
+  <depend>controller_interface</depend>
+  <depend>hardware_interface</depend>
+  <depend>pluginlib</depend>
+  <depend>trajectory_msgs</depend>
+  <depend>cms_beamtime_interfaces</depend>
+  <depend>sensor_msgs</depend>
+
+  <export>
+    <pluginlib plugin="gripper_service_trajectory_controller.xml"/>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/src/gripper_service_trajectory_controller/src/gripper_service_trajectory_controller.cpp
+++ b/src/gripper_service_trajectory_controller/src/gripper_service_trajectory_controller.cpp
@@ -1,0 +1,115 @@
+#include "gripper_service_trajectory_controller/gripper_service_trajectory_controller.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+
+#include "pluginlib/class_list_macros.hpp"
+
+namespace gripper_service_trajectory_controller
+{
+GripperServiceTrajectoryController::GripperServiceTrajectoryController() : controller_interface::ControllerInterface()
+{
+}
+
+controller_interface::InterfaceConfiguration GripperServiceTrajectoryController::command_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  config.names.push_back("joint_finger/position");
+  return config;
+}
+
+controller_interface::InterfaceConfiguration GripperServiceTrajectoryController::state_interface_configuration() const
+{
+  controller_interface::InterfaceConfiguration config;
+  config.type = controller_interface::interface_configuration_type::INDIVIDUAL;
+  config.names.push_back("joint_finger/position");
+  return config;
+}
+
+controller_interface::CallbackReturn GripperServiceTrajectoryController::on_init()
+{
+  auto node = get_node();
+  gripper_client_ = node->create_client<cms_beamtime_interfaces::srv::GripperControlMsg>("gripper_service");
+  joint_state_pub_ = node->create_publisher<sensor_msgs::msg::JointState>("~/joint_states", 10);
+  traj_sub_ = node->create_subscription<trajectory_msgs::msg::JointTrajectory>(
+    "~/joint_trajectory", rclcpp::QoS(1),
+    std::bind(&GripperServiceTrajectoryController::traj_callback, this, std::placeholders::_1));
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn GripperServiceTrajectoryController::on_activate(const rclcpp_lifecycle::State &)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+controller_interface::CallbackReturn GripperServiceTrajectoryController::on_deactivate(const rclcpp_lifecycle::State &)
+{
+  return controller_interface::CallbackReturn::SUCCESS;
+}
+
+void GripperServiceTrajectoryController::traj_callback(const trajectory_msgs::msg::JointTrajectory::SharedPtr msg)
+{
+  traj_buffer_.writeFromNonRT(*msg);
+}
+
+controller_interface::return_type GripperServiceTrajectoryController::update(const rclcpp::Time &, const rclcpp::Duration &)
+{
+  auto traj = traj_buffer_.readFromRT();
+  if (!traj)
+  {
+    return controller_interface::return_type::OK;
+  }
+
+  if (traj->points.empty())
+  {
+    return controller_interface::return_type::OK;
+  }
+
+  double target = 0.0;
+  const auto & point = traj->points.back();
+  if (!point.positions.empty())
+  {
+    target = point.positions[0];
+  }
+
+  std::string command;
+  int32_t grip = 0;
+  if (target <= 0.005)
+  {
+    command = "OPEN";
+    grip = 0;
+  }
+  else if (target >= 0.02)
+  {
+    command = "CLOSE";
+    grip = 100;
+  }
+  else
+  {
+    command = "PARTIAL";
+    grip = static_cast<int32_t>(std::round(target / 0.025 * 100.0));
+  }
+
+  auto request = std::make_shared<cms_beamtime_interfaces::srv::GripperControlMsg::Request>();
+  request->command = command;
+  request->grip = grip;
+  if (gripper_client_->service_is_ready())
+  {
+    gripper_client_->async_send_request(request);
+  }
+
+  sensor_msgs::msg::JointState js;
+  js.header.stamp = get_node()->now();
+  js.name = {"joint_finger"};
+  js.position = {target};
+  joint_state_pub_->publish(js);
+
+  traj_buffer_.reset();
+  return controller_interface::return_type::OK;
+}
+
+}  // namespace gripper_service_trajectory_controller
+
+PLUGINLIB_EXPORT_CLASS(gripper_service_trajectory_controller::GripperServiceTrajectoryController, controller_interface::ControllerInterface)

--- a/src/ur5e_hande_moveit_config/config/ros2_controllers.yaml
+++ b/src/ur5e_hande_moveit_config/config/ros2_controllers.yaml
@@ -22,7 +22,7 @@
         wrist_3_joint: {trajectory: 0.1, goal: 0.1}
 
     gripper_controller:
-      type: joint_trajectory_controller/JointTrajectoryController
+      type: gripper_service_trajectory_controller/GripperServiceTrajectoryController
       joints:
         - joint_finger
       state_publish_rate: 50

--- a/src/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/src/ur_moveit_config/launch/ur_moveit.launch.py
@@ -290,7 +290,14 @@ def launch_setup(context, *args, **kwargs):
         output="screen",
     )
 
-    nodes_to_start = [move_group_node, rviz_node, servo_node]
+    gripper_spawner = Node(
+        package="controller_manager",
+        executable="spawner",
+        arguments=["gripper_controller"],
+        output="screen",
+    )
+
+    nodes_to_start = [move_group_node, rviz_node, servo_node, gripper_spawner]
 
     return nodes_to_start
 

--- a/src/ur_moveit_config/launch/ur_moveit.launch.py
+++ b/src/ur_moveit_config/launch/ur_moveit.launch.py
@@ -290,14 +290,7 @@ def launch_setup(context, *args, **kwargs):
         output="screen",
     )
 
-    gripper_spawner = Node(
-        package="controller_manager",
-        executable="spawner",
-        arguments=["gripper_controller"],
-        output="screen",
-    )
-
-    nodes_to_start = [move_group_node, rviz_node, servo_node, gripper_spawner]
+    nodes_to_start = [move_group_node, rviz_node, servo_node]
 
     return nodes_to_start
 


### PR DESCRIPTION
## Summary
- create `gripper_service_trajectory_controller` plugin that converts trajectory commands into calls to `gripper_service`
- register the new controller in `ros2_controllers.yaml`
- spawn the controller in the MoveIt launch file

## Testing
- `bash test.sh` *(fails: `colcon` not found)*

------

