### PR TITLE
Add "Joint values" mode to MoveToForm (#92)

### DIFF
--- a/src/mtc_gui/mtc_gui/main_window.py
+++ b/src/mtc_gui/mtc_gui/main_window.py
@@ -830,8 +830,12 @@ class MTCMainWindow(QMainWindow):
         # Dropdowns show the UNION: registry poses first, inline poses on top
         # (inline overrides a same-named registry pose for display only).
         merged_poses = {**self.poses_panel.get_poses(), **self.config.get("poses", {})}
-        result = open_task_form(step, idx, merged_poses, self)
+        result = open_task_form(step, idx, merged_poses, self, current_pose=self.current_robot_pose)
         if result is not None:
+            if "_inline_joint_pose" in result:
+                ijp = result.pop("_inline_joint_pose")
+                self.config.setdefault("poses", {})[ijp["name"]] = ijp["values"]
+                self._log(f"Added inline joint pose '{ijp['name']}'")
             self.config["tasks"][idx] = result
             self._refresh_tree()
             self._log(f"Updated step {idx + 1}")

--- a/src/mtc_gui/mtc_gui/task_forms.py
+++ b/src/mtc_gui/mtc_gui/task_forms.py
@@ -96,14 +96,17 @@ def _vision_target_grid(target_name: str) -> dict:
 # --- Dispatch ---
 
 
-def open_task_form(step, step_index, poses, parent=None):
+def open_task_form(step, step_index, poses, parent=None, current_pose=None):
     """Open the edit dialog for a task step. Returns edited step dict or None if cancelled."""
     task_type = step.get("task_type", "")
     form_cls = _FORMS.get(task_type)
     if not form_cls:
         QMessageBox.warning(parent, "Unknown", f"No form for task type: {task_type}")
         return None
-    dialog = form_cls(step, step_index, poses, parent)
+    if form_cls is MoveToForm:
+        dialog = form_cls(step, step_index, poses, parent, current_pose=current_pose)
+    else:
+        dialog = form_cls(step, step_index, poses, parent)
     if dialog.exec() == QDialog.DialogCode.Accepted:
         return dialog.result
     return None
@@ -239,14 +242,32 @@ class BaseTaskForm(QDialog):
 class MoveToForm(BaseTaskForm):
     TITLE = "MoveTo Configuration"
 
-    _MODES = ["Named target", "Relative move", "Cartesian target"]
+    _MODES = ["Named target", "Relative move", "Cartesian target", "Joint values"]
+
+    _JOINT_NAMES = [
+        "Shoulder Pan", "Shoulder Lift", "Elbow",
+        "Wrist 1", "Wrist 2", "Wrist 3",
+    ]
+    _JOINT_PRESETS = {
+        "Home": [0.0, -90.0, -90.0, -90.0, 90.0, 0.0],
+        "Straight Up": [0.0, -90.0, 0.0, -90.0, 0.0, 0.0],
+        "All Zero": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+    }
+
+    def __init__(self, step, step_index, poses, parent=None, current_pose=None):
+        self._current_pose = current_pose
+        self._step_index = step_index
+        super().__init__(step, step_index, poses, parent)
 
     def _detect_mode(self):
-        """Match backend precedence: relative > cartesian > named."""
+        """Match backend precedence: relative > cartesian > joint > named."""
         if self.step.get("direction") and float(self.step.get("distance", 0)) != 0:
             return "Relative move"
         if self.step.get("cartesian_target"):
             return "Cartesian target"
+        target = self.step.get("target", "")
+        if target and self.poses.get(target) and len(self.poses[target]) == 6:
+            return "Joint values"
         return "Named target"
 
     def build_form(self):
@@ -350,19 +371,69 @@ class MoveToForm(BaseTaskForm):
         self.frame_id.setCurrentText(self.step.get("frame_id", "base_link"))
         cart.addRow("Frame:", self.frame_id)
 
+        # --- Joint values section ---
+        self._joint_group = QGroupBox("Joint Values")
+        jl = QFormLayout(self._joint_group)
+        self.form.addRow(self._joint_group)
+
+        # Load existing joint values if editing a joint-mode step
+        existing_jv = []
+        target = self.step.get("target", "")
+        if target and self.poses.get(target) and len(self.poses[target]) == 6:
+            existing_jv = self.poses[target]
+
+        self.joint_spins = []
+        for i, jname in enumerate(self._JOINT_NAMES):
+            spin = QDoubleSpinBox()
+            spin.setRange(-360.0, 360.0)
+            spin.setDecimals(2)
+            spin.setSuffix(" deg")
+            if i < len(existing_jv):
+                spin.setValue(existing_jv[i])
+            jl.addRow(f"{jname}:", spin)
+            self.joint_spins.append(spin)
+
+        # Presets row
+        preset_row = QHBoxLayout()
+        for pname, pvals in self._JOINT_PRESETS.items():
+            btn = QPushButton(pname)
+            btn.clicked.connect(lambda checked, v=pvals: self._apply_joint_preset(v))
+            preset_row.addWidget(btn)
+        jl.addRow("Presets:", preset_row)
+
+        # Read current pose button
+        self._read_pose_btn = QPushButton("Read current pose")
+        self._read_pose_btn.clicked.connect(self._read_current_pose)
+        jl.addRow(self._read_pose_btn)
+
         # Wire mode switching
         self.mode_combo.currentTextChanged.connect(self._apply_mode)
         self._apply_mode(self.mode_combo.currentText())
+
+    def _apply_joint_preset(self, values):
+        for spin, val in zip(self.joint_spins, values):
+            spin.setValue(val)
+
+    def _read_current_pose(self):
+        if self._current_pose is None:
+            QMessageBox.warning(
+                self, "No Pose", "No robot pose available. Is the robot connected?"
+            )
+            return
+        for spin, val in zip(self.joint_spins, self._current_pose):
+            spin.setValue(val)
 
     def _apply_mode(self, mode):
         self._named_group.setVisible(mode == "Named target")
         self._rel_group.setVisible(mode == "Relative move")
         self._cart_group.setVisible(mode == "Cartesian target")
         self._planning_group.setVisible(mode == "Cartesian target")
+        self._joint_group.setVisible(mode == "Joint values")
         previews = {
             "Named target": f"Will execute: move to '{self.target.text()}'",
             "Relative move": "Will execute: relative move in selected direction",
             "Cartesian target": "Will execute: move to XYZ coordinates",
+            "Joint values": "Will execute: move to explicit joint angles",
         }
         self._preview.setText(previews.get(mode, ""))
 
@@ -370,7 +441,7 @@ class MoveToForm(BaseTaskForm):
         s = {**self.step}
         mode = self.mode_combo.currentText()
 
-        # Always strip all three branches, then add back only the active one
+        # Always strip all branches, then add back only the active one
         for k in (
             "target",
             "direction",
@@ -378,6 +449,7 @@ class MoveToForm(BaseTaskForm):
             "cartesian_target",
             "frame_id",
             "planning_type",
+            "_inline_joint_pose",
         ):
             s.pop(k, None)
 
@@ -396,6 +468,15 @@ class MoveToForm(BaseTaskForm):
                 cart.extend([r, p, yaw])
             s["cartesian_target"] = cart
             s["frame_id"] = self.frame_id.currentText()
+        elif mode == "Joint values":
+            # Reuse existing inline name or generate one from step index
+            target = self.step.get("target", "")
+            if not (target and self.poses.get(target) and len(self.poses[target]) == 6):
+                target = f"moveto_joints_{self._step_index + 1}"
+            s["target"] = target
+            s["planning_type"] = "joint"
+            values = [spin.value() for spin in self.joint_spins]
+            s["_inline_joint_pose"] = {"name": target, "values": values}
         return s
 
 

--- a/src/mtc_gui/test/test_moveto_form.py
+++ b/src/mtc_gui/test/test_moveto_form.py
@@ -82,9 +82,72 @@ def test_ambiguous_step_defaults_to_relative():
     assert "cartesian_target" not in result
 
 
+def test_joint_mode_emits_target_and_inline_pose():
+    """Selecting Joint values, setting 6 spinboxes → step has target + _inline_joint_pose."""
+    form = MoveToForm({"task_type": "move_to"}, 2, {})
+    form.mode_combo.setCurrentText("Joint values")
+    angles = [10.0, -20.0, 30.0, -40.0, 50.0, -60.0]
+    for spin, val in zip(form.joint_spins, angles):
+        spin.setValue(val)
+    result = form.collect_values()
+    assert result["target"] == "moveto_joints_3"
+    assert result["_inline_joint_pose"]["name"] == "moveto_joints_3"
+    assert result["_inline_joint_pose"]["values"] == angles
+    assert "direction" not in result
+    assert "distance" not in result
+    assert "cartesian_target" not in result
+
+
+def test_joint_mode_detected_from_poses():
+    """Step with target pointing at a 6-element poses entry → defaults to Joint values."""
+    poses = {"my_joint_pose": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+    step = {"task_type": "move_to", "target": "my_joint_pose"}
+    form = MoveToForm(step, 0, poses)
+    assert form.mode_combo.currentText() == "Joint values"
+    # Spinboxes should be loaded with the pose values
+    for spin, expected in zip(form.joint_spins, poses["my_joint_pose"]):
+        assert spin.value() == expected
+    # Collect preserves the name
+    result = form.collect_values()
+    assert result["target"] == "my_joint_pose"
+    assert result["_inline_joint_pose"]["values"] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+def test_read_current_pose_fills_spinboxes():
+    """Read current pose button fills spinboxes from provided current_pose."""
+    pose = [11.0, 22.0, 33.0, 44.0, 55.0, 66.0]
+    form = MoveToForm({"task_type": "move_to"}, 0, {}, current_pose=pose)
+    form.mode_combo.setCurrentText("Joint values")
+    form._read_current_pose()
+    for spin, expected in zip(form.joint_spins, pose):
+        assert spin.value() == expected
+
+
+def test_read_current_pose_none_no_crash(monkeypatch):
+    """Read current pose with no live pose warns and leaves spinboxes untouched."""
+    # QMessageBox.warning is modal and blocks even under offscreen Qt, so patch
+    # it out; we only care that the no-pose path is handled without filling.
+    import mtc_gui.task_forms as tf
+
+    warned = {}
+    monkeypatch.setattr(
+        tf.QMessageBox, "warning",
+        lambda *a, **k: warned.setdefault("called", True),
+    )
+    form = MoveToForm({"task_type": "move_to"}, 0, {}, current_pose=None)
+    form.mode_combo.setCurrentText("Joint values")
+    form._read_current_pose()
+    assert warned.get("called") is True
+    # Spinboxes stay at default 0.0 — no live pose was injected.
+    assert all(spin.value() == 0.0 for spin in form.joint_spins)
+
+
 if __name__ == "__main__":
     test_cartesian_mode_emits_only_cartesian_keys()
     test_relative_mode_emits_only_relative_keys()
     test_named_mode_emits_only_target()
     test_ambiguous_step_defaults_to_relative()
-    print("All MoveToForm tests passed.")
+    test_joint_mode_emits_target_and_inline_pose()
+    test_joint_mode_detected_from_poses()
+    test_read_current_pose_fills_spinboxes()
+    print("All MoveToForm tests passed (run via pytest for the monkeypatch test).")


### PR DESCRIPTION
## Closes #92

The MoveTo operator form accepted a **named** target, a **relative** move, and a **cartesian** target, but offered **no way to enter 6 explicit joint angles**. To do a joint-space move, an operator had to first create a named pose in the pose manager and then reference it — there was no direct path.

## What changed (GUI-only — no backend touch)
Builds on the mode selector added in #93. Adds a fourth mode, **Joint values**, to `MoveToForm`:
- **6 joint-angle spinboxes** (degrees, -360..360), reusing the exact widget spec from `PoseEditorDialog`, with the same **Home / Straight Up / All Zero presets**.
- A **"Read current pose"** button that fills the spinboxes from the live robot pose. If no live pose is available it shows the same "No robot pose available. Is the robot connected?" warning used elsewhere in the GUI.
- On save, the typed angles are injected into the **global `poses` bag** under an auto-generated name (`moveto_joints_<n>`, or the existing inline name when editing), and `target` is set to that name. This is exactly how the backend already resolves a joint move (`move_to_stages.py`: when `target` is a key in the poses dict, its value is treated as 6 joint angles in degrees) — so **no `.action`, orchestrator, or stage change is needed**.
- Mode auto-detects on open: a step whose `target` points at a 6-element poses entry loads in **Joint values** mode with the spinboxes pre-filled.

The `_inline_joint_pose` helper key is stripped from the step in `main_window` before it is stored, so it never reaches the wire — only the standard `target` + global `poses` entry do.

No change to any backend file — verified the diff touches only `src/mtc_gui/`.

## Verification
- **Unit tests** (`src/mtc_gui/test/test_moveto_form.py`, offscreen Qt, matching existing style): joint mode emits `target` + inline pose and none of the other modes' keys; a step pointing at a 6-element pose auto-detects Joint mode and pre-fills; "Read current pose" fills from a provided pose; the no-pose path warns without filling. **8/8 pass**, `ruff check` clean.
- **Live mock-hardware integration test:** brought up the standalone stack (`ros2 launch cms_moveit_config robot_bringup.launch.py gripper:=hande use_mock_hardware:=true`), confirmed `/joint_states` publishing, then drove the real data path — live joint state → the bridge's radians→degrees / arm-joint-order conversion → `MoveToForm._read_current_pose` → spinboxes → `collect_values`. The spinboxes filled with the live robot angles and the produced step was a consistent joint move pointing at the inline pose. This exercises the one path that can't be covered by offscreen unit tests alone.