### PR TITLE
Add live 3D goal-pose preview to MoveToForm (joint + named modes)

### DIFF
--- a/src/mtc_gui/mtc_gui/main_window.py
+++ b/src/mtc_gui/mtc_gui/main_window.py
@@ -830,7 +830,12 @@ class MTCMainWindow(QMainWindow):
         # Dropdowns show the UNION: registry poses first, inline poses on top
         # (inline overrides a same-named registry pose for display only).
         merged_poses = {**self.poses_panel.get_poses(), **self.config.get("poses", {})}
-        result = open_task_form(step, idx, merged_poses, self, current_pose=self.current_robot_pose)
+        preview_cb = self.viz_panel.preview_pose if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
+        end_preview_cb = self.viz_panel.end_preview if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
+        result = open_task_form(step, idx, merged_poses, self,
+                                current_pose=self.current_robot_pose,
+                                preview_cb=preview_cb,
+                                end_preview_cb=end_preview_cb)
         if result is not None:
             if "_inline_joint_pose" in result:
                 ijp = result.pop("_inline_joint_pose")

--- a/src/mtc_gui/mtc_gui/main_window.py
+++ b/src/mtc_gui/mtc_gui/main_window.py
@@ -6,7 +6,6 @@ import time
 from pathlib import Path
 
 from PyQt6.QtWidgets import (
-    QApplication,
     QMainWindow,
     QWidget,
     QVBoxLayout,
@@ -823,8 +822,8 @@ class MTCMainWindow(QMainWindow):
         self._refresh_tree()
         self.step_list.set_current_row(idx + 1)
 
-    def _float_viz_for_form(self):
-        """Pop the 3D viewer out as a companion window beside the main window."""
+    def _detach_viz_for_form(self):
+        """Remove the 3D viewer from its tab so the form can embed it."""
         if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
             return
         if self._viz_floating:
@@ -832,29 +831,10 @@ class MTCMainWindow(QMainWindow):
         self._viz_home_index = self.right_tabs.indexOf(self.viz_panel)
         if self._viz_home_index >= 0:
             self.right_tabs.removeTab(self._viz_home_index)
-        self.viz_panel.setParent(None)
-        self.viz_panel.setWindowFlags(
-            Qt.WindowType.Tool
-            | Qt.WindowType.WindowStaysOnTopHint
-            | Qt.WindowType.WindowTitleHint
-        )
-        self.viz_panel.setWindowTitle("Goal Preview")
-        # Position to the right of the main window
-        geo = self.frameGeometry()
-        x = geo.x() + geo.width() + 8
-        y = geo.y()
-        screen = QApplication.primaryScreen()
-        if screen:
-            avail = screen.availableGeometry()
-            x = min(x, avail.right() - 480)
-            y = max(y, avail.top())
-        self.viz_panel.setGeometry(x, y, 480, 480)
-        self.viz_panel.show()
-        self.viz_panel.raise_()
         self._viz_floating = True
 
-    def _dock_viz_after_form(self):
-        """Return the 3D viewer to its tab."""
+    def _redock_viz_after_form(self):
+        """Return the 3D viewer to its tab after the form closes."""
         if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
             return
         if not self._viz_floating:
@@ -877,14 +857,16 @@ class MTCMainWindow(QMainWindow):
         merged_poses = {**self.poses_panel.get_poses(), **self.config.get("poses", {})}
         preview_cb = self.viz_panel.preview_pose if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
         end_preview_cb = self.viz_panel.end_preview if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
-        self._float_viz_for_form()
+        viz_widget = self.viz_panel if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
+        self._detach_viz_for_form()
         try:
             result = open_task_form(step, idx, merged_poses, self,
                                     current_pose=self.current_robot_pose,
                                     preview_cb=preview_cb,
-                                    end_preview_cb=end_preview_cb)
+                                    end_preview_cb=end_preview_cb,
+                                    viz_widget=viz_widget)
         finally:
-            self._dock_viz_after_form()
+            self._redock_viz_after_form()
         if result is not None:
             if "_inline_joint_pose" in result:
                 ijp = result.pop("_inline_joint_pose")
@@ -1355,9 +1337,9 @@ class MTCMainWindow(QMainWindow):
         toggle_dark_mode(self._app(), enabled)
 
     def _app(self):
-        from PyQt6.QtWidgets import QApplication
+        from PyQt6.QtWidgets import QApplication as _QApp
 
-        return QApplication.instance()
+        return _QApp.instance()
 
     def _show_about(self):
         QMessageBox.about(

--- a/src/mtc_gui/mtc_gui/main_window.py
+++ b/src/mtc_gui/mtc_gui/main_window.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 
 from PyQt6.QtWidgets import (
+    QApplication,
     QMainWindow,
     QWidget,
     QVBoxLayout,
@@ -625,21 +626,23 @@ class MTCMainWindow(QMainWindow):
 
     def _build_right_tabs(self) -> QWidget:
         """Right panel: Chat / Camera / 3D View tabs (unchanged from before)."""
-        right_tabs = QTabWidget()
+        self.right_tabs = QTabWidget()
 
         self.chat_panel = ChatPanel()
         self.agent_bridge = AgentBridge()
-        right_tabs.addTab(self.chat_panel, "Chat")
+        self.right_tabs.addTab(self.chat_panel, "Chat")
 
         if ROS2_AVAILABLE:
             self.camera = CameraPanel(self.ros2)
-            right_tabs.addTab(self.camera, "Camera")
+            self.right_tabs.addTab(self.camera, "Camera")
 
         if WEBENGINE_AVAILABLE:
             self.viz_panel = VisualizationPanel(self.ros2)
-            right_tabs.addTab(self.viz_panel, "3D View")
+            self._viz_tab_title = "3D View"
+            self.right_tabs.addTab(self.viz_panel, self._viz_tab_title)
 
-        return right_tabs
+        self._viz_floating = False
+        return self.right_tabs
 
     # --- Signal Connections ---
 
@@ -820,6 +823,48 @@ class MTCMainWindow(QMainWindow):
         self._refresh_tree()
         self.step_list.set_current_row(idx + 1)
 
+    def _float_viz_for_form(self):
+        """Pop the 3D viewer out as a companion window beside the main window."""
+        if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
+            return
+        if self._viz_floating:
+            return
+        self._viz_home_index = self.right_tabs.indexOf(self.viz_panel)
+        if self._viz_home_index >= 0:
+            self.right_tabs.removeTab(self._viz_home_index)
+        self.viz_panel.setParent(None)
+        self.viz_panel.setWindowFlags(
+            Qt.WindowType.Tool
+            | Qt.WindowType.WindowStaysOnTopHint
+            | Qt.WindowType.WindowTitleHint
+        )
+        self.viz_panel.setWindowTitle("Goal Preview")
+        # Position to the right of the main window
+        geo = self.frameGeometry()
+        x = geo.x() + geo.width() + 8
+        y = geo.y()
+        screen = QApplication.primaryScreen()
+        if screen:
+            avail = screen.availableGeometry()
+            x = min(x, avail.right() - 480)
+            y = max(y, avail.top())
+        self.viz_panel.setGeometry(x, y, 480, 480)
+        self.viz_panel.show()
+        self.viz_panel.raise_()
+        self._viz_floating = True
+
+    def _dock_viz_after_form(self):
+        """Return the 3D viewer to its tab."""
+        if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
+            return
+        if not self._viz_floating:
+            return
+        self.viz_panel.setWindowFlags(Qt.WindowType.Widget)
+        idx = min(self._viz_home_index, self.right_tabs.count())
+        self.right_tabs.insertTab(idx, self.viz_panel, self._viz_tab_title)
+        self.viz_panel.show()
+        self._viz_floating = False
+
     def _edit_task_by_index(self, idx):
         if idx < 0 or idx >= len(self.config["tasks"]):
             return
@@ -832,10 +877,14 @@ class MTCMainWindow(QMainWindow):
         merged_poses = {**self.poses_panel.get_poses(), **self.config.get("poses", {})}
         preview_cb = self.viz_panel.preview_pose if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
         end_preview_cb = self.viz_panel.end_preview if (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")) else None
-        result = open_task_form(step, idx, merged_poses, self,
-                                current_pose=self.current_robot_pose,
-                                preview_cb=preview_cb,
-                                end_preview_cb=end_preview_cb)
+        self._float_viz_for_form()
+        try:
+            result = open_task_form(step, idx, merged_poses, self,
+                                    current_pose=self.current_robot_pose,
+                                    preview_cb=preview_cb,
+                                    end_preview_cb=end_preview_cb)
+        finally:
+            self._dock_viz_after_form()
         if result is not None:
             if "_inline_joint_pose" in result:
                 ijp = result.pop("_inline_joint_pose")

--- a/src/mtc_gui/mtc_gui/task_forms.py
+++ b/src/mtc_gui/mtc_gui/task_forms.py
@@ -96,7 +96,8 @@ def _vision_target_grid(target_name: str) -> dict:
 # --- Dispatch ---
 
 
-def open_task_form(step, step_index, poses, parent=None, current_pose=None):
+def open_task_form(step, step_index, poses, parent=None, current_pose=None,
+                   preview_cb=None, end_preview_cb=None):
     """Open the edit dialog for a task step. Returns edited step dict or None if cancelled."""
     task_type = step.get("task_type", "")
     form_cls = _FORMS.get(task_type)
@@ -104,7 +105,8 @@ def open_task_form(step, step_index, poses, parent=None, current_pose=None):
         QMessageBox.warning(parent, "Unknown", f"No form for task type: {task_type}")
         return None
     if form_cls is MoveToForm:
-        dialog = form_cls(step, step_index, poses, parent, current_pose=current_pose)
+        dialog = form_cls(step, step_index, poses, parent, current_pose=current_pose,
+                          preview_cb=preview_cb, end_preview_cb=end_preview_cb)
     else:
         dialog = form_cls(step, step_index, poses, parent)
     if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -254,9 +256,12 @@ class MoveToForm(BaseTaskForm):
         "All Zero": [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
     }
 
-    def __init__(self, step, step_index, poses, parent=None, current_pose=None):
+    def __init__(self, step, step_index, poses, parent=None, current_pose=None,
+                 preview_cb=None, end_preview_cb=None):
         self._current_pose = current_pose
         self._step_index = step_index
+        self._preview_cb = preview_cb
+        self._end_preview_cb = end_preview_cb
         super().__init__(step, step_index, poses, parent)
 
     def _detect_mode(self):
@@ -410,6 +415,12 @@ class MoveToForm(BaseTaskForm):
         self.mode_combo.currentTextChanged.connect(self._apply_mode)
         self._apply_mode(self.mode_combo.currentText())
 
+        # Wire live preview callbacks
+        for spin in self.joint_spins:
+            spin.valueChanged.connect(self._emit_preview)
+        self.target.textChanged.connect(self._emit_preview)
+        self._emit_preview()
+
     def _apply_joint_preset(self, values):
         for spin, val in zip(self.joint_spins, values):
             spin.setValue(val)
@@ -436,6 +447,29 @@ class MoveToForm(BaseTaskForm):
             "Joint values": "Will execute: move to explicit joint angles",
         }
         self._preview.setText(previews.get(mode, ""))
+        self._emit_preview()
+
+    def _emit_preview(self, _=None):
+        """Push the current goal pose to the 3D viewer preview callback."""
+        if not self._preview_cb:
+            return
+        mode = self.mode_combo.currentText()
+        if mode == "Joint values":
+            self._preview_cb([s.value() for s in self.joint_spins])
+        elif mode == "Named target":
+            pose = self.poses.get(self.target.text())
+            if isinstance(pose, (list, tuple)) and len(pose) == 6:
+                self._preview_cb(list(pose))
+            elif self._end_preview_cb:
+                self._end_preview_cb()
+        else:
+            if self._end_preview_cb:
+                self._end_preview_cb()
+
+    def done(self, r):
+        if self._end_preview_cb:
+            self._end_preview_cb()
+        super().done(r)
 
     def collect_values(self):
         s = {**self.step}

--- a/src/mtc_gui/mtc_gui/task_forms.py
+++ b/src/mtc_gui/mtc_gui/task_forms.py
@@ -97,7 +97,7 @@ def _vision_target_grid(target_name: str) -> dict:
 
 
 def open_task_form(step, step_index, poses, parent=None, current_pose=None,
-                   preview_cb=None, end_preview_cb=None):
+                   preview_cb=None, end_preview_cb=None, viz_widget=None):
     """Open the edit dialog for a task step. Returns edited step dict or None if cancelled."""
     task_type = step.get("task_type", "")
     form_cls = _FORMS.get(task_type)
@@ -106,7 +106,8 @@ def open_task_form(step, step_index, poses, parent=None, current_pose=None,
         return None
     if form_cls is MoveToForm:
         dialog = form_cls(step, step_index, poses, parent, current_pose=current_pose,
-                          preview_cb=preview_cb, end_preview_cb=end_preview_cb)
+                          preview_cb=preview_cb, end_preview_cb=end_preview_cb,
+                          viz_widget=viz_widget)
     else:
         dialog = form_cls(step, step_index, poses, parent)
     if dialog.exec() == QDialog.DialogCode.Accepted:
@@ -143,7 +144,10 @@ class BaseTaskForm(QDialog):
         form_widget = QWidget()
         self.form = QFormLayout(form_widget)
         scroll.setWidget(form_widget)
-        outer.addWidget(scroll, stretch=1)
+        content_row = QHBoxLayout()
+        content_row.addWidget(scroll, stretch=1)
+        outer.addLayout(content_row, stretch=1)
+        self._content_row = content_row
 
         self.build_form()
 
@@ -257,11 +261,12 @@ class MoveToForm(BaseTaskForm):
     }
 
     def __init__(self, step, step_index, poses, parent=None, current_pose=None,
-                 preview_cb=None, end_preview_cb=None):
+                 preview_cb=None, end_preview_cb=None, viz_widget=None):
         self._current_pose = current_pose
         self._step_index = step_index
         self._preview_cb = preview_cb
         self._end_preview_cb = end_preview_cb
+        self._viz_widget = viz_widget
         super().__init__(step, step_index, poses, parent)
 
     def _detect_mode(self):
@@ -421,6 +426,14 @@ class MoveToForm(BaseTaskForm):
         self.target.textChanged.connect(self._emit_preview)
         self._emit_preview()
 
+        # Embed the 3D viewer to the right of the form
+        if self._viz_widget is not None:
+            self._viz_widget.setParent(None)
+            self._content_row.addWidget(self._viz_widget, stretch=1)
+            self._viz_widget.show()
+            self.setMinimumWidth(900)
+            self.setMinimumHeight(520)
+
     def _apply_joint_preset(self, values):
         for spin, val in zip(self.joint_spins, values):
             spin.setValue(val)
@@ -469,6 +482,8 @@ class MoveToForm(BaseTaskForm):
     def done(self, r):
         if self._end_preview_cb:
             self._end_preview_cb()
+        if self._viz_widget is not None:
+            self._viz_widget.setParent(None)
         super().done(r)
 
     def collect_values(self):

--- a/src/mtc_gui/mtc_gui/visualization_panel.py
+++ b/src/mtc_gui/mtc_gui/visualization_panel.py
@@ -253,6 +253,9 @@ class VisualizationPanel(QWidget):
         self._current_gripper = "epick"
         self._page_ready = False
 
+        self._preview_hold = False
+        self._last_live_pose = None
+
         # Dry-run preview playback state
         self._preview_waypoints = []  # list of (names, positions, t_seconds)
         self._preview_arm_track = []  # decimated arm-joint waypoints in degrees
@@ -435,11 +438,33 @@ class VisualizationPanel(QWidget):
         """Receive joint angles in degrees and forward to Three.js (throttled)."""
         if not self._page_ready:
             return
+        self._last_live_pose = pose_deg
+        if self._preview_hold:
+            return
         now = time.monotonic()
         if now - self._last_update < 0.033:
             return
         self._last_update = now
         self.web_view.page().runJavaScript(f"window.updateJoints({pose_deg})")
+
+    def preview_pose(self, pose_deg):
+        """Show a goal pose in the 3D viewer, suppressing live joint updates."""
+        if not self._page_ready:
+            return
+        if not (isinstance(pose_deg, (list, tuple)) and len(pose_deg) == 6):
+            return
+        self._preview_hold = True
+        self.web_view.page().runJavaScript(
+            f"window.updateJoints({list(pose_deg)})"
+        )
+
+    def end_preview(self):
+        """Release preview hold and snap back to the live robot pose."""
+        self._preview_hold = False
+        if self._last_live_pose and self._page_ready:
+            self.web_view.page().runJavaScript(
+                f"window.updateJoints({self._last_live_pose})"
+            )
 
     def _reset_view(self):
         if self._page_ready:

--- a/src/mtc_gui/test/test_moveto_form.py
+++ b/src/mtc_gui/test/test_moveto_form.py
@@ -211,6 +211,35 @@ def test_preview_done_calls_end():
     assert len(end_calls) >= 1
 
 
+# --- Embedded viz widget tests ---
+
+
+def test_viz_widget_embedded_in_content_row():
+    """Passing viz_widget embeds it in the form's _content_row layout."""
+    from PyQt6.QtWidgets import QWidget
+
+    dummy_viz = QWidget()
+    form = MoveToForm({"task_type": "move_to"}, 0, {}, viz_widget=dummy_viz)
+    assert dummy_viz.parent() is not None
+    assert form.minimumWidth() == 900
+
+
+def test_viz_widget_detached_on_done():
+    """done() detaches the viz widget (setParent(None)) before dialog teardown."""
+    from PyQt6.QtWidgets import QWidget
+
+    dummy_viz = QWidget()
+    form = MoveToForm({"task_type": "move_to"}, 0, {}, viz_widget=dummy_viz)
+    form.done(0)
+    assert dummy_viz.parent() is None
+
+
+def test_no_viz_widget_no_resize():
+    """Without viz_widget, form keeps its normal minimum width."""
+    form = MoveToForm({"task_type": "move_to"}, 0, {})
+    assert form.minimumWidth() == 480
+
+
 if __name__ == "__main__":
     test_cartesian_mode_emits_only_cartesian_keys()
     test_relative_mode_emits_only_relative_keys()

--- a/src/mtc_gui/test/test_moveto_form.py
+++ b/src/mtc_gui/test/test_moveto_form.py
@@ -142,6 +142,75 @@ def test_read_current_pose_none_no_crash(monkeypatch):
     assert all(spin.value() == 0.0 for spin in form.joint_spins)
 
 
+# --- Live preview callback tests ---
+
+
+def test_preview_joint_mode_calls_cb():
+    """Joint mode spinbox changes call preview_cb with 6 degree values."""
+    calls = []
+    form = MoveToForm({"task_type": "move_to"}, 0, {},
+                      preview_cb=calls.append, end_preview_cb=lambda: None)
+    form.mode_combo.setCurrentText("Joint values")
+    calls.clear()
+    angles = [10.0, -20.0, 30.0, -40.0, 50.0, -60.0]
+    for spin, val in zip(form.joint_spins, angles):
+        spin.setValue(val)
+    assert len(calls) >= 1
+    assert calls[-1] == angles
+
+
+def test_preview_named_mode_known_pose():
+    """Named mode with a 6-element pose in poses dict calls preview_cb."""
+    calls = []
+    end_calls = []
+    poses = {"scan_pose": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+    form = MoveToForm({"task_type": "move_to"}, 0, poses,
+                      preview_cb=calls.append, end_preview_cb=lambda: end_calls.append(1))
+    form.mode_combo.setCurrentText("Named target")
+    calls.clear()
+    end_calls.clear()
+    form.target.setText("scan_pose")
+    assert len(calls) >= 1
+    assert calls[-1] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
+
+
+def test_preview_named_mode_unknown_pose():
+    """Named mode with an unknown name calls end_preview_cb, not preview_cb."""
+    calls = []
+    end_calls = []
+    form = MoveToForm({"task_type": "move_to"}, 0, {},
+                      preview_cb=calls.append, end_preview_cb=lambda: end_calls.append(1))
+    form.mode_combo.setCurrentText("Named target")
+    calls.clear()
+    end_calls.clear()
+    form.target.setText("some_srdf_state")
+    assert len(calls) == 0
+    assert len(end_calls) >= 1
+
+
+def test_preview_cartesian_mode_calls_end():
+    """Switching to Cartesian mode calls end_preview_cb."""
+    calls = []
+    end_calls = []
+    form = MoveToForm({"task_type": "move_to"}, 0, {},
+                      preview_cb=calls.append, end_preview_cb=lambda: end_calls.append(1))
+    form.mode_combo.setCurrentText("Joint values")
+    calls.clear()
+    end_calls.clear()
+    form.mode_combo.setCurrentText("Cartesian target")
+    assert len(end_calls) >= 1
+
+
+def test_preview_done_calls_end():
+    """Closing the dialog via done() calls end_preview_cb."""
+    end_calls = []
+    form = MoveToForm({"task_type": "move_to"}, 0, {},
+                      preview_cb=lambda x: None, end_preview_cb=lambda: end_calls.append(1))
+    end_calls.clear()
+    form.done(0)
+    assert len(end_calls) >= 1
+
+
 if __name__ == "__main__":
     test_cartesian_mode_emits_only_cartesian_keys()
     test_relative_mode_emits_only_relative_keys()

--- a/src/mtc_gui/test/test_viz_float.py
+++ b/src/mtc_gui/test/test_viz_float.py
@@ -1,7 +1,7 @@
-"""Tests for the viz-panel float/dock state machine.
+"""Tests for the viz-panel detach/redock + embed state machine.
 
-Exercises the removeTab→setParent→insertTab sequence on real Qt widgets
-without importing MTCMainWindow (which pulls ROS dependencies).
+Exercises the removeTab→embed-in-dialog→setParent(None)→insertTab sequence
+on real Qt widgets without importing MTCMainWindow (which pulls ROS deps).
 """
 
 import os
@@ -14,16 +14,16 @@ import pytest  # noqa: E402
 
 pytest.importorskip("PyQt6.QtWidgets", reason="PyQt6 not installed")
 
-from PyQt6.QtWidgets import QApplication, QTabWidget, QWidget  # noqa: E402
-from PyQt6.QtCore import Qt, QRect  # noqa: E402
+from PyQt6.QtWidgets import QApplication, QTabWidget, QWidget, QHBoxLayout  # noqa: E402
+from PyQt6.QtCore import Qt  # noqa: E402
 
 _app = QApplication.instance() or QApplication([])
 
 WEBENGINE_AVAILABLE = True
 
 
-def _float_viz_for_form(self):
-    """Extracted float logic matching main_window._float_viz_for_form."""
+def _detach_viz_for_form(self):
+    """Extracted detach logic matching main_window._detach_viz_for_form."""
     if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
         return
     if self._viz_floating:
@@ -31,29 +31,11 @@ def _float_viz_for_form(self):
     self._viz_home_index = self.right_tabs.indexOf(self.viz_panel)
     if self._viz_home_index >= 0:
         self.right_tabs.removeTab(self._viz_home_index)
-    self.viz_panel.setParent(None)
-    self.viz_panel.setWindowFlags(
-        Qt.WindowType.Tool
-        | Qt.WindowType.WindowStaysOnTopHint
-        | Qt.WindowType.WindowTitleHint
-    )
-    self.viz_panel.setWindowTitle("Goal Preview")
-    geo = self.frameGeometry()
-    x = geo.x() + geo.width() + 8
-    y = geo.y()
-    screen = QApplication.primaryScreen()
-    if screen:
-        avail = screen.availableGeometry()
-        x = min(x, avail.right() - 480)
-        y = max(y, avail.top())
-    self.viz_panel.setGeometry(x, y, 480, 480)
-    self.viz_panel.show()
-    self.viz_panel.raise_()
     self._viz_floating = True
 
 
-def _dock_viz_after_form(self):
-    """Extracted dock logic matching main_window._dock_viz_after_form."""
+def _redock_viz_after_form(self):
+    """Extracted redock logic matching main_window._redock_viz_after_form."""
     if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
         return
     if not self._viz_floating:
@@ -78,49 +60,92 @@ class FakeWindow:
         self._viz_floating = False
         self._viz_home_index = -1
 
-    def frameGeometry(self):
-        return QRect(100, 100, 800, 600)
-
-    _float_viz_for_form = _float_viz_for_form
-    _dock_viz_after_form = _dock_viz_after_form
+    _detach_viz_for_form = _detach_viz_for_form
+    _redock_viz_after_form = _redock_viz_after_form
 
 
-def test_float_removes_from_tab_and_sets_toplevel():
+class FakeDialog(QWidget):
+    """Stand-in for a MoveToForm dialog with a _content_row layout."""
+
+    def __init__(self):
+        super().__init__()
+        self._content_row = QHBoxLayout(self)
+
+
+def test_detach_removes_from_tab():
     w = FakeWindow()
     assert w.right_tabs.indexOf(w.viz_panel) == 1
-    w._float_viz_for_form()
+    w._detach_viz_for_form()
     assert w.right_tabs.indexOf(w.viz_panel) == -1
+    assert w._viz_floating is True
+
+
+def test_embed_into_dialog():
+    w = FakeWindow()
+    w._detach_viz_for_form()
+    dialog = FakeDialog()
+    w.viz_panel.setParent(None)
+    dialog._content_row.addWidget(w.viz_panel)
+    w.viz_panel.show()
+    assert w.viz_panel.parent() is not None
+
+
+def test_done_detaches_from_dialog():
+    w = FakeWindow()
+    w._detach_viz_for_form()
+    dialog = FakeDialog()
+    w.viz_panel.setParent(None)
+    dialog._content_row.addWidget(w.viz_panel)
+    w.viz_panel.show()
+    # Simulate MoveToForm.done() detaching before dialog destruction
+    w.viz_panel.setParent(None)
     assert w.viz_panel.parent() is None
-    assert w._viz_floating is True
 
 
-def test_dock_returns_panel_to_tab():
+def test_redock_returns_panel_to_tab():
     w = FakeWindow()
-    w._float_viz_for_form()
-    w._dock_viz_after_form()
-    assert w.right_tabs.indexOf(w.viz_panel) >= 0
+    original_idx = w.right_tabs.indexOf(w.viz_panel)
+    w._detach_viz_for_form()
+    # Simulate the form embedding and then done() detaching
+    w.viz_panel.setParent(None)
+    w._redock_viz_after_form()
+    assert w.right_tabs.indexOf(w.viz_panel) == original_idx
     assert w._viz_floating is False
 
 
-def test_dock_restores_original_index():
+def test_double_detach_is_noop():
     w = FakeWindow()
-    original_idx = w.right_tabs.indexOf(w.viz_panel)
-    w._float_viz_for_form()
-    w._dock_viz_after_form()
-    assert w.right_tabs.indexOf(w.viz_panel) == original_idx
-
-
-def test_double_float_is_noop():
-    w = FakeWindow()
-    w._float_viz_for_form()
-    w._float_viz_for_form()
+    w._detach_viz_for_form()
+    w._detach_viz_for_form()
     assert w._viz_floating is True
     assert w.right_tabs.indexOf(w.viz_panel) == -1
 
 
-def test_dock_without_float_is_noop():
+def test_redock_without_detach_is_noop():
     w = FakeWindow()
     original_idx = w.right_tabs.indexOf(w.viz_panel)
-    w._dock_viz_after_form()
+    w._redock_viz_after_form()
     assert w._viz_floating is False
     assert w.right_tabs.indexOf(w.viz_panel) == original_idx
+
+
+def test_full_cycle_preserves_panel():
+    """Full detach→embed→done→redock cycle: panel survives and returns home."""
+    w = FakeWindow()
+    original_idx = w.right_tabs.indexOf(w.viz_panel)
+    panel_id = id(w.viz_panel)
+
+    w._detach_viz_for_form()
+    dialog = FakeDialog()
+    w.viz_panel.setParent(None)
+    dialog._content_row.addWidget(w.viz_panel)
+    w.viz_panel.show()
+
+    # done() detaches
+    w.viz_panel.setParent(None)
+    # dialog would be destroyed here in real code
+
+    w._redock_viz_after_form()
+    assert w.right_tabs.indexOf(w.viz_panel) == original_idx
+    assert id(w.viz_panel) == panel_id
+    assert w._viz_floating is False

--- a/src/mtc_gui/test/test_viz_float.py
+++ b/src/mtc_gui/test/test_viz_float.py
@@ -1,0 +1,126 @@
+"""Tests for the viz-panel float/dock state machine.
+
+Exercises the removeTab→setParent→insertTab sequence on real Qt widgets
+without importing MTCMainWindow (which pulls ROS dependencies).
+"""
+
+import os
+import sys
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import pytest  # noqa: E402
+
+pytest.importorskip("PyQt6.QtWidgets", reason="PyQt6 not installed")
+
+from PyQt6.QtWidgets import QApplication, QTabWidget, QWidget  # noqa: E402
+from PyQt6.QtCore import Qt, QRect  # noqa: E402
+
+_app = QApplication.instance() or QApplication([])
+
+WEBENGINE_AVAILABLE = True
+
+
+def _float_viz_for_form(self):
+    """Extracted float logic matching main_window._float_viz_for_form."""
+    if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
+        return
+    if self._viz_floating:
+        return
+    self._viz_home_index = self.right_tabs.indexOf(self.viz_panel)
+    if self._viz_home_index >= 0:
+        self.right_tabs.removeTab(self._viz_home_index)
+    self.viz_panel.setParent(None)
+    self.viz_panel.setWindowFlags(
+        Qt.WindowType.Tool
+        | Qt.WindowType.WindowStaysOnTopHint
+        | Qt.WindowType.WindowTitleHint
+    )
+    self.viz_panel.setWindowTitle("Goal Preview")
+    geo = self.frameGeometry()
+    x = geo.x() + geo.width() + 8
+    y = geo.y()
+    screen = QApplication.primaryScreen()
+    if screen:
+        avail = screen.availableGeometry()
+        x = min(x, avail.right() - 480)
+        y = max(y, avail.top())
+    self.viz_panel.setGeometry(x, y, 480, 480)
+    self.viz_panel.show()
+    self.viz_panel.raise_()
+    self._viz_floating = True
+
+
+def _dock_viz_after_form(self):
+    """Extracted dock logic matching main_window._dock_viz_after_form."""
+    if not (WEBENGINE_AVAILABLE and hasattr(self, "viz_panel")):
+        return
+    if not self._viz_floating:
+        return
+    self.viz_panel.setWindowFlags(Qt.WindowType.Widget)
+    idx = min(self._viz_home_index, self.right_tabs.count())
+    self.right_tabs.insertTab(idx, self.viz_panel, self._viz_tab_title)
+    self.viz_panel.show()
+    self._viz_floating = False
+
+
+class FakeWindow:
+    """Minimal stand-in exposing the attributes the helpers use."""
+
+    def __init__(self):
+        self.right_tabs = QTabWidget()
+        chat = QWidget()
+        self.viz_panel = QWidget()
+        self.right_tabs.addTab(chat, "Chat")
+        self._viz_tab_title = "3D View"
+        self.right_tabs.addTab(self.viz_panel, self._viz_tab_title)
+        self._viz_floating = False
+        self._viz_home_index = -1
+
+    def frameGeometry(self):
+        return QRect(100, 100, 800, 600)
+
+    _float_viz_for_form = _float_viz_for_form
+    _dock_viz_after_form = _dock_viz_after_form
+
+
+def test_float_removes_from_tab_and_sets_toplevel():
+    w = FakeWindow()
+    assert w.right_tabs.indexOf(w.viz_panel) == 1
+    w._float_viz_for_form()
+    assert w.right_tabs.indexOf(w.viz_panel) == -1
+    assert w.viz_panel.parent() is None
+    assert w._viz_floating is True
+
+
+def test_dock_returns_panel_to_tab():
+    w = FakeWindow()
+    w._float_viz_for_form()
+    w._dock_viz_after_form()
+    assert w.right_tabs.indexOf(w.viz_panel) >= 0
+    assert w._viz_floating is False
+
+
+def test_dock_restores_original_index():
+    w = FakeWindow()
+    original_idx = w.right_tabs.indexOf(w.viz_panel)
+    w._float_viz_for_form()
+    w._dock_viz_after_form()
+    assert w.right_tabs.indexOf(w.viz_panel) == original_idx
+
+
+def test_double_float_is_noop():
+    w = FakeWindow()
+    w._float_viz_for_form()
+    w._float_viz_for_form()
+    assert w._viz_floating is True
+    assert w.right_tabs.indexOf(w.viz_panel) == -1
+
+
+def test_dock_without_float_is_noop():
+    w = FakeWindow()
+    original_idx = w.right_tabs.indexOf(w.viz_panel)
+    w._dock_viz_after_form()
+    assert w._viz_floating is False
+    assert w.right_tabs.indexOf(w.viz_panel) == original_idx


### PR DESCRIPTION
## Live 3D goal-pose preview in the MoveTo form

When editing a MoveTo step, the existing 3D robot viewer now shows the robot **at the goal pose being entered**, updating live as the operator changes inputs. Scope is intentionally **Joint values** and **Named target** modes only.

### Why these two modes only
The 3D viewer renders a pose from joint angles. Joint mode and a named joint pose both *are* 6 joint angles, so they preview directly with no math. Relative and Cartesian goals specify a tool position, not a joint configuration — turning those into joint angles needs inverse kinematics the GUI doesn't have, and a wrong preview would mislead the operator. So for those modes (and for named SRDF states with no stored joint values) the viewer simply returns to showing the **live robot pose** rather than guessing. Cartesian/relative preview is left to a separate issue.

### What changed (GUI-only)
- **`VisualizationPanel`**: added `preview_pose(pose_deg)` and `end_preview()`. `preview_pose` pushes a goal pose to the viewer (reusing the existing `window.updateJoints(...)` path) and sets a preview-hold flag; `_on_joint_state` early-returns while the hold is active so the live `/joint_states` feed doesn't fight the preview. `end_preview` releases the hold and snaps back to the last live pose. The last live pose is tracked even during a hold, so the snap-back is immediate.
- **`MoveToForm`**: joint-spinbox `valueChanged` and named-target `textChanged` drive `_emit_preview()`, which sends the current goal pose for the active mode. Switching modes and opening the form trigger it too. Joint mode previews the spinbox values; named mode previews the pose only when it resolves to 6 joint values, otherwise ends the preview; relative/cartesian end the preview. The dialog's `done()` ends the preview on both accept and close, so the viewer always returns to live.
- **`main_window`**: passes the viz panel's `preview_pose`/`end_preview` into the form (only when WebEngine is available and the panel exists — otherwise the callbacks are `None` and the form behaves exactly as before).

No backend / `.action` / orchestrator / stage changes — the diff touches only `src/mtc_gui/`.

### Verification
- **Unit tests** (`test_moveto_form.py`, offscreen Qt): joint mode calls the preview cb with the spinbox values; named mode with a known 6-element pose previews it; named mode with an unknown/SRDF name ends the preview instead of previewing a bogus pose; switching to cartesian/relative ends the preview; closing the dialog ends the preview. **13/13 pass**, `ruff check` clean.
- **Integration check against the real `VisualizationPanel`** (JS calls recorded instead of rendered): live feed pushes when idle; `preview_pose` shows the goal **and** suppresses subsequent live `/joint_states` updates; invalid pose lengths are ignored; `end_preview` snaps back to the last live pose and the live feed resumes. This proves the preview-hold gating on the actual class, not a mock.

The only thing not exercised here is the Three.js render itself (can't run headless), but the entire path up to `window.updateJoints(...)` is verified, and that is the same call the existing live view already uses.