### PR TITLE
Make MoveTo named-target field a dropdown of available poses

### DIFF
--- a/src/mtc_gui/mtc_gui/task_forms.py
+++ b/src/mtc_gui/mtc_gui/task_forms.py
@@ -295,9 +295,22 @@ class MoveToForm(BaseTaskForm):
         self._named_group = QGroupBox("Named Target")
         named_layout = QFormLayout(self._named_group)
         self.form.addRow(self._named_group)
-        self.target = QLineEdit(str(self.step.get("target", "moveit_home")))
+        self.target = QComboBox()
+        self.target.setEditable(True)
+        self.target.setInsertPolicy(QComboBox.InsertPolicy.NoInsert)
+        pose_names = sorted(self.poses.keys())
+        self.target.addItems(pose_names)
+        for sentinel in ("moveit_home",):
+            if self.target.findText(sentinel) < 0:
+                self.target.addItem(sentinel)
+        current = str(self.step.get("target", "moveit_home"))
+        i = self.target.findText(current)
+        if i >= 0:
+            self.target.setCurrentIndex(i)
+        else:
+            self.target.setEditText(current)
         named_layout.addRow("Target:", self.target)
-        hint = QLabel("Named state (moveit_home) or pose name from the pose manager")
+        hint = QLabel("Pick a pose or type an SRDF named state (e.g. moveit_home)")
         hint.setStyleSheet("color: gray; font-size: 10px;")
         named_layout.addRow(hint)
 
@@ -423,7 +436,7 @@ class MoveToForm(BaseTaskForm):
         # Wire live preview callbacks
         for spin in self.joint_spins:
             spin.valueChanged.connect(self._emit_preview)
-        self.target.textChanged.connect(self._emit_preview)
+        self.target.currentTextChanged.connect(self._emit_preview)
         self._emit_preview()
 
         # Embed the 3D viewer to the right of the form
@@ -454,7 +467,7 @@ class MoveToForm(BaseTaskForm):
         self._planning_group.setVisible(mode == "Cartesian target")
         self._joint_group.setVisible(mode == "Joint values")
         previews = {
-            "Named target": f"Will execute: move to '{self.target.text()}'",
+            "Named target": f"Will execute: move to '{self.target.currentText()}'",
             "Relative move": "Will execute: relative move in selected direction",
             "Cartesian target": "Will execute: move to XYZ coordinates",
             "Joint values": "Will execute: move to explicit joint angles",
@@ -470,7 +483,7 @@ class MoveToForm(BaseTaskForm):
         if mode == "Joint values":
             self._preview_cb([s.value() for s in self.joint_spins])
         elif mode == "Named target":
-            pose = self.poses.get(self.target.text())
+            pose = self.poses.get(self.target.currentText())
             if isinstance(pose, (list, tuple)) and len(pose) == 6:
                 self._preview_cb(list(pose))
             elif self._end_preview_cb:
@@ -503,7 +516,7 @@ class MoveToForm(BaseTaskForm):
             s.pop(k, None)
 
         if mode == "Named target":
-            s["target"] = self.target.text()
+            s["target"] = self.target.currentText()
             s["planning_type"] = "joint"
         elif mode == "Relative move":
             s["direction"] = self.direction.currentText()

--- a/src/mtc_gui/test/test_moveto_form.py
+++ b/src/mtc_gui/test/test_moveto_form.py
@@ -169,7 +169,7 @@ def test_preview_named_mode_known_pose():
     form.mode_combo.setCurrentText("Named target")
     calls.clear()
     end_calls.clear()
-    form.target.setText("scan_pose")
+    form.target.setCurrentText("scan_pose")
     assert len(calls) >= 1
     assert calls[-1] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
@@ -183,7 +183,7 @@ def test_preview_named_mode_unknown_pose():
     form.mode_combo.setCurrentText("Named target")
     calls.clear()
     end_calls.clear()
-    form.target.setText("some_srdf_state")
+    form.target.setEditText("some_srdf_state")
     assert len(calls) == 0
     assert len(end_calls) >= 1
 
@@ -238,6 +238,51 @@ def test_no_viz_widget_no_resize():
     """Without viz_widget, form keeps its normal minimum width."""
     form = MoveToForm({"task_type": "move_to"}, 0, {})
     assert form.minimumWidth() == 480
+
+
+# --- Named-target dropdown tests ---
+
+
+def test_named_target_combo_populated():
+    """Combo box lists all pose names plus moveit_home sentinel."""
+    poses = {"alpha": [1, 2, 3, 4, 5, 6], "beta": [0] * 6, "gamma": [0] * 6}
+    form = MoveToForm({"task_type": "move_to"}, 0, poses)
+    items = [form.target.itemText(i) for i in range(form.target.count())]
+    for name in poses:
+        assert name in items
+    assert "moveit_home" in items
+
+
+def test_named_target_dropdown_selection_collects():
+    """Selecting from dropdown round-trips through collect_values."""
+    poses = {"pose_a": [0] * 6, "pose_b": [0] * 6}
+    form = MoveToForm({"task_type": "move_to"}, 0, poses)
+    form.mode_combo.setCurrentText("Named target")
+    form.target.setCurrentText("pose_b")
+    result = form.collect_values()
+    assert result["target"] == "pose_b"
+
+
+def test_named_target_arbitrary_text_collects():
+    """Typing a value not in the list still round-trips (editable combo)."""
+    form = MoveToForm({"task_type": "move_to"}, 0, {})
+    form.mode_combo.setCurrentText("Named target")
+    form.target.setEditText("custom_srdf_state")
+    result = form.collect_values()
+    assert result["target"] == "custom_srdf_state"
+
+
+def test_named_target_dropdown_fires_preview():
+    """Changing combo to a known pose fires the preview callback."""
+    calls = []
+    poses = {"scan": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]}
+    form = MoveToForm({"task_type": "move_to"}, 0, poses,
+                      preview_cb=calls.append, end_preview_cb=lambda: None)
+    form.mode_combo.setCurrentText("Named target")
+    calls.clear()
+    form.target.setCurrentText("scan")
+    assert len(calls) >= 1
+    assert calls[-1] == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Named-target field is now a dropdown of available poses

The MoveTo form's **Named target** field was a free-text box; you had to remember and type the exact pose name. It's now an **editable dropdown** listing every available pose.

### What it does
- The dropdown is populated from `self.poses` — which is the **merged** pose set: pose-manager registry poses (poses.yaml) **and** inline poses added to the task config. Both show up, sorted.
- `moveit_home` is always offered even if it isn't in the pose bag.
- The combo is **editable** (`NoInsert` policy) so you can still type an arbitrary SRDF named state that isn't a stored pose — typing doesn't pollute the list.
- Loading a step pre-selects its saved target if it's in the list, otherwise shows it as edit text (so existing tasks with any target value still load correctly).

### Implementation
- Replaced the `QLineEdit` with an editable `QComboBox` in `MoveToForm.build_form()`.
- Migrated every downstream usage of the old text API: `self.target.text()` → `currentText()` (preview label, `_emit_preview`, `collect_values`) and `self.target.textChanged` → `currentTextChanged` (live-preview wiring). `currentTextChanged` fires for both dropdown selection and edits to the editable line, so the goal-pose preview still updates on either.
- GUI-only; `task_forms.py` is the only production file touched. No backend change, no change to how the merged pose set is built.

### Verification
- Tests added to `test_moveto_form.py`: the combo is populated from the poses dict (+ `moveit_home`); selecting a pose round-trips through `collect_values`; typing a value not in the list round-trips; the named-mode preview callback still fires on selection.
- Full `src/mtc_gui/test/` suite: **36 passed**, `ruff check` clean.
- Smoke-instantiated offscreen with a sample poses dict including an inline pose — confirmed the dropdown lists registry + inline poses, loads the step's current value, and round-trips both a dropdown pick and a typed SRDF state.